### PR TITLE
Scan settings folder recursively

### DIFF
--- a/template.go
+++ b/template.go
@@ -56,8 +56,8 @@ func NewTemplateParser(cfg Config) *TemplateParser {
 				return nil
 			}
 
-			key := strings.ReplaceAll(path, "/", "_")
-			key = strings.TrimPrefix(key, fmt.Sprintf("%s_", cfg.Settings))
+			key := strings.ReplaceAll(filepath.ToSlash(path), "/", "_")
+			key = strings.TrimPrefix(key, fmt.Sprintf("%s_", strings.ReplaceAll(filepath.ToSlash(cfg.Settings), "/", "_")))
 			key = strings.TrimSuffix(key, ".json")
 
 			t.Vars[key] = v

--- a/template_test.go
+++ b/template_test.go
@@ -17,7 +17,10 @@ func ExampleTemplateParser_marshal() {
 		return
 	}
 
-	defer os.Remove(tmpfile.Name())
+	defer func() {
+		_ = os.Remove(tmpfile.Name())
+	}()
+
 	if _, err := tmpfile.Write(originalTemplate); err != nil {
 		fmt.Println(err.Error())
 		return
@@ -125,7 +128,9 @@ func ExampleTemplateParser_include() {
 		return
 	}
 
-	defer os.Remove(tmpfile.Name())
+	defer func() {
+		_ = os.Remove(tmpfile.Name())
+	}()
 	if _, err := tmpfile.Write(originalTemplate); err != nil {
 		fmt.Println(err.Error())
 		return
@@ -141,7 +146,10 @@ func ExampleTemplateParser_include() {
 		return
 	}
 
-	defer os.Remove(includeTmpfile.Name())
+	defer func() {
+		_ = os.Remove(includeTmpfile.Name())
+	}()
+
 	if _, err := includeTmpfile.Write([]byte(fmt.Sprintf("{{ include \"%s\" }}", tmpfile.Name()))); err != nil {
 		fmt.Println(err.Error())
 		return


### PR DESCRIPTION
As described in issue https://github.com/devopsfaith/krakend-flexibleconfig/issues/18 , scanning the `FC_SETTINGS` folder recursively would allow grouping settings by different criteria, and thus having a better structured configuration.

With this approach:

````
root
│   settings.json    {"key": "value"}
│
└───group1
    │   settings.json {"key": "value"}
    │   
    └───subgroup1
        │   settings.json {"key": "value"}
````

will result in a map with the following key, value pairs:

````
map[settings: map[key: value], group1_settings: map[key: value], group1_subgroup1_settings: map[key: value]]
````

access to specific keys in the corresponding map values is still done via dot notation.

